### PR TITLE
Fix for 'import *' may pollute namespace

### DIFF
--- a/python_brfied/__init__.py
+++ b/python_brfied/__init__.py
@@ -30,9 +30,23 @@ from python_brfied import env as env
 from python_brfied import exceptions as exceptions
 from python_brfied import validations as validations
 from python_brfied.shortcuts import zip as zip  # type: ignore
-
+__all__ = [
 __all__ = [
     "choices",
+    "datetime",
+    "env",
+    "exceptions",
+    "validations",
+    "zip",
+    "str2bool",
+    "percentage",
+    "instantiate_class",
+    "build_chain",
+    "BaseHandler",
+    "BaseDirector",
+]
+    "choices",
+
     "datetime",
     "env",
     "exceptions",

--- a/python_brfied/__init__.py
+++ b/python_brfied/__init__.py
@@ -24,13 +24,27 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 __author__ = 'Kelson da Costa Medeiros <kelsoncm@gmail.com>'
 
 from typing import List
-from python_brfied.choices import *
-from python_brfied.datetime import *
-from python_brfied.env import *
-from python_brfied.exceptions import *
-from python_brfied.validations import *
-from python_brfied.validations import *
-from python_brfied.shortcuts.zip import *
+from python_brfied import choices as choices
+from python_brfied import datetime as datetime
+from python_brfied import env as env
+from python_brfied import exceptions as exceptions
+from python_brfied import validations as validations
+from python_brfied.shortcuts import zip as zip  # type: ignore
+
+__all__ = [
+    "choices",
+    "datetime",
+    "env",
+    "exceptions",
+    "validations",
+    "zip",
+    "str2bool",
+    "percentage",
+    "instantiate_class",
+    "build_chain",
+    "BaseHandler",
+    "BaseDirector",
+]
 
 
 def str2bool(v):


### PR DESCRIPTION
In general, the fix is to stop using `from module import *` when the target module does not define `__all__`, and instead either (a) import the module itself (`import module as _choices`) and explicitly export what you want via this package’s own `__all__`, or (b) explicitly enumerate the imported names (`from module import A, B, C`). Since we cannot edit the submodules and don’t know their exact symbol lists, the safest approach inside `__init__.py` is to import the submodules normally and, if desired, expose them via this package’s namespace.

Concretely, in `python_brfied/__init__.py`, we will replace all the `from python_brfied.xxx import *` lines with non-star imports:

- Replace `from python_brfied.choices import *` with `from python_brfied import choices as choices`.
- Similarly replace `datetime`, `env`, `exceptions`, `validations`, and `shortcuts.zip` star imports with `from python_brfied import datetime as datetime`, etc., plus an explicit import for `python_brfied.shortcuts.zip as zip` (or a qualified name). This preserves access to those modules via attributes on the `python_brfied` package (e.g., `python_brfied.choices`) without polluting the namespace with all their internals.
- To retain approximate backward compatibility for users who may expect these names at the package level, we can add a `__all__` list in `__init__.py` that explicitly enumerates the public symbols defined in this file. Since we cannot see into other modules, we will not enumerate their internals; but we can at least expose the submodules themselves and the helper functions/classes defined here (`str2bool`, `percentage`, `instantiate_class`, `build_chain`, `BaseHandler`, `BaseDirector`). Consumers can still reach submodule contents via `python_brfied.choices`, etc.

No new external methods or complex helpers are needed; we only adjust the import style and add `__all__` in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._