### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/test_shortcut_sync_http.py
+++ b/tests/test_shortcut_sync_http.py
@@ -29,7 +29,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from http.client import HTTPException
 from python_brfied.shortcuts.sync_http import get, get_json, get_zip, get_zip_content, get_zip_csv_content, \
     get_zip_fwf_content
-from pyfwf.descriptors import FileDescriptor, HeaderRowDescriptor, DetailRowDescriptor
+from pyfwf.descriptors import HeaderRowDescriptor, DetailRowDescriptor
 from pyfwf.columns import CharColumn
 from tests import FILE01_CSV_EXPECTED, FILE01_CSV_EXPECTED_BINARY, FILE01_CSV_EXPECTED_LATIN1
 from tests import FILE02_JSON_EXPECTED, FILE02_JSON_EXPECTED_BINARY, FILE02_JSON_EXPECTED_LATIN1


### PR DESCRIPTION
To fix the problem, we should remove the unused `FileDescriptor` symbol from the import statement while leaving the other imported descriptors (`HeaderRowDescriptor`, `DetailRowDescriptor`) intact, since they may be used elsewhere in the file. This keeps the test behavior unchanged while eliminating the unnecessary import.

Concretely, in `tests/test_shortcut_sync_http.py`, update the import on line 32 so that it no longer mentions `FileDescriptor`. The line should import only the actually used descriptors. No additional methods, definitions, or external libraries are required; this is just a minor cleanup of the import list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._