### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/test_shortcut_sync_http.py
+++ b/tests/test_shortcut_sync_http.py
@@ -30,7 +30,6 @@ from http.client import HTTPException
 from python_brfied.shortcuts.sync_http import get, get_json, get_zip, get_zip_content, get_zip_csv_content, \
     get_zip_fwf_content
 from pyfwf.descriptors import HeaderRowDescriptor, DetailRowDescriptor
-from pyfwf.columns import CharColumn
 from tests import FILE01_CSV_EXPECTED, FILE01_CSV_EXPECTED_BINARY, FILE01_CSV_EXPECTED_LATIN1
 from tests import FILE02_JSON_EXPECTED, FILE02_JSON_EXPECTED_BINARY, FILE02_JSON_EXPECTED_LATIN1
 from tests import ZIP_EXPECTED, JSON_EXPECTED, CSV_EXPECTED


### PR DESCRIPTION
To fix the problem, we should remove the unused import of `CharColumn` so that every imported symbol is actually referenced in the file. This reduces clutter and satisfies the CodeQL rule about unused imports.

Concretely, in `tests/test_shortcut_sync_http.py`, at the top of the file among the imports, there is a line:

```py
from pyfwf.columns import CharColumn
```

Since `CharColumn` is not used anywhere in this test module, delete this line entirely. No additional imports, methods, or definitions are required, and no other code changes are needed. This preserves all existing behavior while eliminating the unused import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._