### PR TITLE
Fix for Syntax error

### DIFF
--- a/python_brfied/__init__.py
+++ b/python_brfied/__init__.py
@@ -30,49 +30,20 @@ from python_brfied import env as env
 from python_brfied import exceptions as exceptions
 from python_brfied import validations as validations
 from python_brfied.shortcuts import zip as zip  # type: ignore
-__all__ = [
-__all__ = [
-    "choices",
-    "datetime",
-    "env",
-    "exceptions",
-    "validations",
-    "zip",
-    "str2bool",
-    "percentage",
-    "instantiate_class",
-    "build_chain",
-    "BaseHandler",
-    "BaseDirector",
-]
-    "choices",
-
-    "datetime",
-    "env",
-    "exceptions",
-    "validations",
-    "zip",
-    "str2bool",
-    "percentage",
-    "instantiate_class",
-    "build_chain",
-    "BaseHandler",
-    "BaseDirector",
-]
-    "choices",
-
-    "datetime",
-    "env",
-    "exceptions",
-    "validations",
-    "zip",
-    "str2bool",
-    "percentage",
-    "instantiate_class",
-    "build_chain",
-    "BaseHandler",
-    "BaseDirector",
-]
+    __all__ = [
+        "choices",
+        "datetime",
+        "env",
+        "exceptions",
+        "validations",
+        "zip",
+        "str2bool",
+        "percentage",
+        "instantiate_class",
+        "build_chain",
+        "BaseHandler",
+        "BaseDirector",
+    ]
 
 
 def str2bool(v):


### PR DESCRIPTION
In general, we should replace the malformed, duplicated `__all__` definitions with a single syntactically correct list containing the intended exported names. That means: keep just one `__all__ = [` assignment, include the items once in the list, and close the bracket properly. Remove all duplicated `__all__ = [` lines and stray repeated blocks of identifiers that are currently outside any list literal.

The best fix with minimal functional change is to infer the intended `__all__` contents from the repeated blocks (they all list the same names) and define `__all__` once at the place it currently appears (around lines 33–47). Concretely: in `python_brfied/__init__.py`, replace the entire corrupted region starting from the first `__all__ = [` (line 33) down through the last repeated block (line 75) with a single, clean `__all__` list:

```py
__all__ = [
    "choices",
    "datetime",
    "env",
    "exceptions",
    "validations",
    "zip",
    "str2bool",
    "percentage",
    "instantiate_class",
    "build_chain",
    "BaseHandler",
    "BaseDirector",
]
```

No new methods or imports are required; we are only fixing syntax and deduping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._